### PR TITLE
Admin can change accessory status

### DIFF
--- a/app/controllers/admin/accessories_controller.rb
+++ b/app/controllers/admin/accessories_controller.rb
@@ -8,9 +8,14 @@ class Admin::AccessoriesController < Admin::BaseController
   end
 
   def update
-    accessory = Accessory.find(params[:id])
-    accessory.update(accessory_params)
-    redirect_to accessory_path(accessory)
+    @accessory = Accessory.find(params[:id])
+    if @accessory.update(accessory_params)
+      flash[:notice] = "#{@accessory.title} updated."
+      redirect_to accessory_path(@accessory)
+    else
+      flash[:error] = 'Something went wrong.'
+      render :edit
+    end
   end
 
   private

--- a/app/views/admin/accessories/_form.html.erb
+++ b/app/views/admin/accessories/_form.html.erb
@@ -8,5 +8,7 @@
   <%= f.label :description %>
   <%= f.text_area :description %>
 
+  <%= f.check_box(:role, {}, "active", "retired") %>
+
   <%= f.submit %>
 <% end %>

--- a/app/views/admin/accessories/_form.html.erb
+++ b/app/views/admin/accessories/_form.html.erb
@@ -8,6 +8,7 @@
   <%= f.label :description %>
   <%= f.text_area :description %>
 
+  <%= f.label :role, 'Active' %>
   <%= f.check_box(:role, {}, "active", "retired") %>
 
   <%= f.submit %>

--- a/spec/features/admin/dashboard/admin_can_edit_accessory_spec.rb
+++ b/spec/features/admin/dashboard/admin_can_edit_accessory_spec.rb
@@ -33,13 +33,13 @@ describe 'As an admin' do
 
       visit edit_admin_accessory_path(accessory)
 
-      expect(page).to have_checked_field('acessory[role]')
+      expect(page).to have_checked_field('accessory[role]')
 
       uncheck('accessory[role]')
 
       click_on 'Update Accessory'
 
-      expect(page).to have_content("#{accessory.name} updated.")
+      expect(page).to have_content("#{accessory.title} updated.")
 
       expect(page).to_not have_button('Add to Cart')
     end

--- a/spec/features/admin/dashboard/admin_can_edit_accessory_spec.rb
+++ b/spec/features/admin/dashboard/admin_can_edit_accessory_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'As an admin' do
-  it 'I can edit an accessory' do
+  scenario 'I can edit an accessory' do
     admin = create(:admin)
     accessory_1, accesstory_2 = create_list(:accessory, 2)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
@@ -24,7 +24,24 @@ describe 'As an admin' do
     expect(page).to have_content(10)
     expect(page).to have_content("Renaming cuz I can cuz I'm an admin")
   end
-  it 'I can change accessory status' do
 
+  describe 'I can change accessory status' do
+    scenario 'from active to inactive' do
+      admin = create(:admin)
+      accessory = create(:accessory)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit edit_admin_accessory_path(accessory)
+
+      expect(page).to have_checked_field('acessory[role]')
+
+      uncheck('accessory[role]')
+
+      click_on 'Update Accessory'
+
+      expect(page).to have_content("#{accessory.name} updated.")
+
+      expect(page).to_not have_button('Add to Cart')
+    end
   end
 end

--- a/spec/features/admin/dashboard/admin_can_edit_accessory_spec.rb
+++ b/spec/features/admin/dashboard/admin_can_edit_accessory_spec.rb
@@ -43,5 +43,25 @@ describe 'As an admin' do
 
       expect(page).to_not have_button('Add to Cart')
     end
+
+    scenario 'from active to inactive' do
+      admin = create(:admin)
+      accessory = create(:accessory)
+      accessory.role = 'retired'
+      accessory.save!
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit edit_admin_accessory_path(accessory)
+
+      expect(page).to have_unchecked_field('accessory[role]')
+
+      check('accessory[role]')
+
+      click_on 'Update Accessory'
+
+      expect(page).to have_content("#{accessory.title} updated.")
+
+      expect(page).to have_button('Add to Cart')
+    end
   end
 end


### PR DESCRIPTION
Closes #98 

# Changes Proposed:
- Lets admin change accessory from active to inactive and vice versa

# Fixes:
- N/A

# Checklist:
* Tested on RSPEC? ✅
* All test passing? ✅
* Ran on Local Host? ✅

# Mentions:
