### PR TITLE
Admin dashboard

### DIFF
--- a/app/controllers/admin/accessories_controller.rb
+++ b/app/controllers/admin/accessories_controller.rb
@@ -10,7 +10,7 @@ class Admin::AccessoriesController < Admin::BaseController
   def update
     @accessory = Accessory.find(params[:id])
     if @accessory.update(accessory_params)
-      flash[:notice] = "#{@accessory.title} updated."
+      flash[:success] = "#{@accessory.title} updated."
       redirect_to accessory_path(@accessory)
     else
       flash[:error] = 'Something went wrong.'

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,4 +1,5 @@
 class Admin::DashboardController < Admin::BaseController
   def index
+    @orders = Order.all
   end
 end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,5 +1,12 @@
 class Admin::DashboardController < Admin::BaseController
   def index
     @orders = Order.all
+    @orders_by_status = orders_by_status
   end
+
+ private
+
+   def orders_by_status
+    Order.where(status: params[:status])
+   end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,0 +1,5 @@
+class Admin::OrdersController < Admin::BaseController
+
+  def show
+  end
+end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -2,4 +2,16 @@ class Admin::OrdersController < Admin::BaseController
 
   def show
   end
+
+  def update
+    order = Order.find(params[:id])
+    order.update(status: params[:status])
+    if order.save
+      flash[:success] = "Updated status to #{params[:status]}."
+    else
+      flash[:error] = "Unable to update order status."
+    end
+      redirect_to admin_dashboard_path(status: params[:status])
+  end
+
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,7 +2,7 @@ class OrdersController < ApplicationController
   include ActionView::Helpers::NumberHelper
 
   def create
-    order = Order.create!(user: current_user, status: 'ordered')
+    order = Order.create!(user: current_user, status: 'Ordered')
     total = 0
     @cart.items.each do |item|
       OrderAccessory.create!(

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -11,4 +11,20 @@ class Order < ApplicationRecord
       sum + (item.quantity * item.accessory.price)
     end
   end
+
+  def self.ordered_count
+    where(status: 'Ordered').count
+  end
+
+  def self.paid_count
+    where(status: 'Paid').count
+  end
+
+  def self.completed_count
+    where(status: 'Completed').count
+  end
+
+  def self.cancelled_count
+    where(status: 'Cancelled').count
+  end
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,3 +1,15 @@
 <section class='title'>
   <%= link_to 'View All Accessories', admin_accessories_path %>
-</section
+</section>
+
+<section class='title'>
+  <h3> Total Number of Orders by Status</h3>
+</section>
+  Ordered: <%= @orders.ordered_count %>
+  Paid: <%= @orders.paid_count %>
+  Cancelled: <%= @orders.cancelled_count %>
+  Completed: <%= @orders.completed_count %>
+
+  <%= @orders.each do |order| %>
+  <% link_to "Order #{order.id}", admin_order_path(order) %>
+  <% end %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -10,6 +10,6 @@
   Cancelled: <%= @orders.cancelled_count %>
   Completed: <%= @orders.completed_count %>
 
-  <%= @orders.each do |order| %>
-  <% link_to "Order #{order.id}", admin_order_path(order) %>
+  <% @orders.each do |order| %>
+  <%= link_to "Order ##{order.id}", admin_order_path(order) %>
   <% end %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,6 +1,7 @@
 <section class='title'>
 <h1> Admin Dashboard</h1>
 </section>
+<%= link_to 'Edit Your Info', edit_user_path(current_user)%>
 
 <section class='title'>
   <%= link_to 'View All Accessories', admin_accessories_path %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,4 +1,8 @@
 <section class='title'>
+<h1> Admin Dashboard</h1>
+</section>
+
+<section class='title'>
   <%= link_to 'View All Accessories', admin_accessories_path %>
 </section>
 
@@ -10,6 +14,15 @@
   Cancelled: <%= @orders.cancelled_count %>
   Completed: <%= @orders.completed_count %>
 
+  <section class='title'>
+    <h3> All Orders</h3>
+  </section>
+  <%= form_tag admin_dashboard_path, method: :get  do %>
+    <%= label_tag :status %>
+    <%= select_tag :status, options_for_select([['Ordered'], ['Paid'], ['Canceled'], ['Completed']]) %>
+    <%= submit_tag  "Filter" %>
+  <% end %>
+  <link_to 'Group By Status'>
   <% @orders.each do |order| %>
   <%= link_to "Order ##{order.id}", admin_order_path(order) %>
   <% end %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -9,20 +9,15 @@
 <section class='title'>
   <h3> Total Number of Orders by Status</h3>
 </section>
-  Ordered: <%= @orders.ordered_count %>
-  Paid: <%= @orders.paid_count %>
-  Cancelled: <%= @orders.cancelled_count %>
-  Completed: <%= @orders.completed_count %>
+  <%= link_to 'Ordered', admin_dashboard_path(status: 'Ordered') %>: <%= @orders.ordered_count %>
+  <%= link_to 'Paid', admin_dashboard_path(status: 'Paid') %>: <%= @orders.paid_count %>
+  <%= link_to 'Cancelled', admin_dashboard_path(status: 'Cancelled') %>: <%= @orders.cancelled_count %>
+  <%= link_to 'Completed', admin_dashboard_path(status: 'Completed') %>: <%= @orders.completed_count %>
 
   <section class='title'>
     <h3> All Orders</h3>
   </section>
-  <%= form_tag admin_dashboard_path, method: :get  do %>
-    <%= label_tag :status %>
-    <%= select_tag :status, options_for_select([['Ordered'], ['Paid'], ['Canceled'], ['Completed']]) %>
-    <%= submit_tag  "Filter" %>
-  <% end %>
-  <link_to 'Group By Status'>
+
   <% @orders.each do |order| %>
   <%= link_to "Order ##{order.id}", admin_order_path(order) %>
   <% end %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -14,10 +14,25 @@
   <%= link_to 'Cancelled', admin_dashboard_path(status: 'Cancelled') %>: <%= @orders.cancelled_count %>
   <%= link_to 'Completed', admin_dashboard_path(status: 'Completed') %>: <%= @orders.completed_count %>
 
+<% if @orders_by_status.empty? %>
   <section class='title'>
     <h3> All Orders</h3>
   </section>
-
   <% @orders.each do |order| %>
   <%= link_to "Order ##{order.id}", admin_order_path(order) %>
   <% end %>
+<% else %>
+  <section class='title'>
+    <h3> All Orders with Status: <%= @orders_by_status.first.status %></h3>
+  </section>
+  <% @orders_by_status.each do |order| %>
+    <%= link_to "Order ##{order.id}", admin_order_path(order) %>
+    <% if order.status == 'Ordered'%>
+      <%= link_to 'Mark as Paid', admin_order_path(order, status: 'Paid'), method: 'Put'  %>
+      <%= link_to 'Cancel', admin_order_path(order, status: 'Cancelled'), method: 'Put'%>
+    <% elsif order.status == 'Paid' %>
+    <%= link_to 'Mark as Completed', admin_order_path(order, status: 'Completed'), method: 'Put'  %>
+    <%= link_to 'Cancel', admin_order_path(order, status: 'Cancelled'), method: 'Put'%>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -26,13 +26,15 @@
     <h3> All Orders with Status: <%= @orders_by_status.first.status %></h3>
   </section>
   <% @orders_by_status.each do |order| %>
-    <%= link_to "Order ##{order.id}", admin_order_path(order) %>
-    <% if order.status == 'Ordered'%>
-      <%= link_to 'Mark as Paid', admin_order_path(order, status: 'Paid'), method: 'Put'  %>
+    <div class="order_<%=order.id%>">
+      <%= link_to "Order ##{order.id}", admin_order_path(order) %>
+      <% if order.status == 'Ordered'%>
+        <%= link_to 'Mark as Paid', admin_order_path(order, status: 'Paid'), method: 'Put'  %>
+        <%= link_to 'Cancel', admin_order_path(order, status: 'Cancelled'), method: 'Put'%>
+      <% elsif order.status == 'Paid' %>
+      <%= link_to 'Mark as Completed', admin_order_path(order, status: 'Completed'), method: 'Put'  %>
       <%= link_to 'Cancel', admin_order_path(order, status: 'Cancelled'), method: 'Put'%>
-    <% elsif order.status == 'Paid' %>
-    <%= link_to 'Mark as Completed', admin_order_path(order, status: 'Completed'), method: 'Put'  %>
-    <%= link_to 'Cancel', admin_order_path(order, status: 'Cancelled'), method: 'Put'%>
-    <% end %>
+      <% end %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/users/dashboard.html.erb
+++ b/app/views/users/dashboard.html.erb
@@ -1,4 +1,6 @@
+<div class="title">
 <h1>Welcome <%= current_user.username %></h1>
+</div>
 <%= link_to 'Edit Your Info', edit_user_path(current_user)%>
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     resources :trips, except: %i[index show]
     resources :accessories, path: 'bike-shop', only: [:index, :edit, :update]
     resources :conditions, except: %i[index show]
-    resources :orders, only: %i[show]
+    resources :orders, only: %i[show update]
     get '/dashboard', to: 'dashboard#index'
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     resources :trips, except: %i[index show]
     resources :accessories, path: 'bike-shop', only: [:index, :edit, :update]
     resources :conditions, except: %i[index show]
+    resources :orders, only: %i[show]
     get '/dashboard', to: 'dashboard#index'
   end
 

--- a/spec/features/admin/dashboard/admin_visits_admin_dashboard_spec.rb
+++ b/spec/features/admin/dashboard/admin_visits_admin_dashboard_spec.rb
@@ -51,17 +51,17 @@ describe 'As an admin' do
     before :each do
       @admin = create(:admin)
       @users = create_list(:user, 5)
-      @order_1 = users[0].orders.create!(status: 'Ordered')
-      @order_2 = users[0].orders.create!(status: 'Ordered')
-      @order_3 = users[0].orders.create!(status: 'Paid')
-      @order_4 = users[1].orders.create!(status: 'Cancelled')
-      @order_5 = users[1].orders.create!(status: 'Cancelled')
-      @order_6 = users[2].orders.create!(status: 'Completed')
-      @order_7 = users[3].orders.create!(status: 'Paid')
-      @order_8 = users[3].orders.create!(status: 'Completed')
-      @order_9 = users[4].orders.create!(status: 'Ordered')
-      @orders = [order_1, order_2, order_3, order_4, order_5, order_6, order_7, order_8, order_9]
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+      @order_1 = @users[0].orders.create!(status: 'Ordered')
+      @order_2 = @users[0].orders.create!(status: 'Ordered')
+      @order_3 = @users[0].orders.create!(status: 'Paid')
+      @order_4 = @users[1].orders.create!(status: 'Cancelled')
+      @order_5 = @users[1].orders.create!(status: 'Cancelled')
+      @order_6 = @users[2].orders.create!(status: 'Completed')
+      @order_7 = @users[3].orders.create!(status: 'Paid')
+      @order_8 = @users[3].orders.create!(status: 'Completed')
+      @order_9 = @users[4].orders.create!(status: 'Ordered')
+      @orders = [@order_1, @order_2, @order_3, @order_4, @order_5, @order_6, @order_7, @order_8, @order_9]
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@admin)
     end
     it 'I can see the total number of orders for each status and a link to order show' do
       visit admin_dashboard_path
@@ -71,12 +71,17 @@ describe 'As an admin' do
       expect(page).to have_content('Cancelled: 2')
       expect(page).to have_content('Completed: 2')
 
-        expect(page).to have_link("Order ##{order_1.id}")
-        click_on "Order ##{order_1.id}"
-        expect(current_path).to eq(admin_order_path(order_1))
+      expect(page).to have_link("Order ##{@order_1.id}")
+      click_on "Order ##{@order_1.id}"
+      expect(current_path).to eq(admin_order_path(@order_1))
     end
     it 'and I can filter them by status type' do
+      visit admin_dashboard_path
 
+      click_on 'Ordered'
+
+      save_and_open_page
+      expect(page).to_not have_content("Order ##{@order_3.id}")
     end
   end
 end

--- a/spec/features/admin/dashboard/admin_visits_admin_dashboard_spec.rb
+++ b/spec/features/admin/dashboard/admin_visits_admin_dashboard_spec.rb
@@ -85,5 +85,20 @@ describe 'As an admin' do
       expect(page).to_not have_content("Order ##{@order_3.id}")
       expect(page).to have_link('Paid')
     end
+    it 'and I can update their status type' do
+      visit admin_dashboard_path
+
+      click_on 'Ordered'
+
+      within ".order_#{@order_1.id}" do
+        click_on 'Mark as Paid'
+      end
+      expect(current_path).to eq(admin_dashboard_path)
+      expect(page).to have_content("Updated status to Paid.")
+
+      click_on 'Ordered'
+
+      expect(page).to_not have_content("Order ##{@order_1.id}")
+    end
   end
 end

--- a/spec/features/admin/dashboard/admin_visits_admin_dashboard_spec.rb
+++ b/spec/features/admin/dashboard/admin_visits_admin_dashboard_spec.rb
@@ -80,8 +80,10 @@ describe 'As an admin' do
 
       click_on 'Ordered'
 
-      save_and_open_page
+      expect(page).to have_content('All Orders with Status: Ordered')
+      expect(page).to have_content("Order ##{@order_1.id}")
       expect(page).to_not have_content("Order ##{@order_3.id}")
+      expect(page).to have_link('Paid')
     end
   end
 end

--- a/spec/features/admin/dashboard/admin_visits_admin_dashboard_spec.rb
+++ b/spec/features/admin/dashboard/admin_visits_admin_dashboard_spec.rb
@@ -44,9 +44,35 @@ describe 'As an admin' do
             expect(page).to have_link('Reactivate')
           end
         end
-
       end
+    end
+  end
+  context 'I see all orders' do
+    it 'I can see the total number of orders for each status and a link to order show' do
+      admin = create(:admin)
+      users = create_list(:user, 5)
+      order_1 = users[0].orders.create!(status: 'Ordered')
+      order_2 = users[0].orders.create!(status: 'Ordered')
+      order_3 = users[0].orders.create!(status: 'Paid')
+      order_4 = users[1].orders.create!(status: 'Cancelled')
+      order_5 = users[1].orders.create!(status: 'Cancelled')
+      order_6 = users[2].orders.create!(status: 'Completed')
+      order_7 = users[3].orders.create!(status: 'Paid')
+      order_8 = users[3].orders.create!(status: 'Completed')
+      order_9 = users[4].orders.create!(status: 'Ordered')
+      orders = [order_1, order_2, order_3, order_4, order_5, order_6, order_7, order_8, order_9]
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
+      visit admin_dashboard_path
+
+      expect(page).to have_content('Ordered: 3')
+      expect(page).to have_content('Paid: 2')
+      expect(page).to have_content('Cancelled: 2')
+      expect(page).to have_content('Completed: 2')
+
+      orders.each do |order|
+        expect(page).to have_link("Order ##{order.id}")
+      end
     end
   end
 end

--- a/spec/features/admin/dashboard/admin_visits_admin_dashboard_spec.rb
+++ b/spec/features/admin/dashboard/admin_visits_admin_dashboard_spec.rb
@@ -70,9 +70,9 @@ describe 'As an admin' do
       expect(page).to have_content('Cancelled: 2')
       expect(page).to have_content('Completed: 2')
 
-      orders.each do |order|
-        expect(page).to have_link("Order ##{order.id}")
-      end
+        expect(page).to have_link("Order ##{order_1.id}")
+        click_on "Order ##{order_1.id}"
+        expect(current_path).to eq(admin_order_path(order_1))
     end
   end
 end

--- a/spec/features/admin/dashboard/admin_visits_admin_dashboard_spec.rb
+++ b/spec/features/admin/dashboard/admin_visits_admin_dashboard_spec.rb
@@ -48,21 +48,22 @@ describe 'As an admin' do
     end
   end
   context 'I see all orders' do
-    it 'I can see the total number of orders for each status and a link to order show' do
-      admin = create(:admin)
-      users = create_list(:user, 5)
-      order_1 = users[0].orders.create!(status: 'Ordered')
-      order_2 = users[0].orders.create!(status: 'Ordered')
-      order_3 = users[0].orders.create!(status: 'Paid')
-      order_4 = users[1].orders.create!(status: 'Cancelled')
-      order_5 = users[1].orders.create!(status: 'Cancelled')
-      order_6 = users[2].orders.create!(status: 'Completed')
-      order_7 = users[3].orders.create!(status: 'Paid')
-      order_8 = users[3].orders.create!(status: 'Completed')
-      order_9 = users[4].orders.create!(status: 'Ordered')
-      orders = [order_1, order_2, order_3, order_4, order_5, order_6, order_7, order_8, order_9]
+    before :each do
+      @admin = create(:admin)
+      @users = create_list(:user, 5)
+      @order_1 = users[0].orders.create!(status: 'Ordered')
+      @order_2 = users[0].orders.create!(status: 'Ordered')
+      @order_3 = users[0].orders.create!(status: 'Paid')
+      @order_4 = users[1].orders.create!(status: 'Cancelled')
+      @order_5 = users[1].orders.create!(status: 'Cancelled')
+      @order_6 = users[2].orders.create!(status: 'Completed')
+      @order_7 = users[3].orders.create!(status: 'Paid')
+      @order_8 = users[3].orders.create!(status: 'Completed')
+      @order_9 = users[4].orders.create!(status: 'Ordered')
+      @orders = [order_1, order_2, order_3, order_4, order_5, order_6, order_7, order_8, order_9]
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
-
+    end
+    it 'I can see the total number of orders for each status and a link to order show' do
       visit admin_dashboard_path
 
       expect(page).to have_content('Ordered: 3')
@@ -73,6 +74,9 @@ describe 'As an admin' do
         expect(page).to have_link("Order ##{order_1.id}")
         click_on "Order ##{order_1.id}"
         expect(current_path).to eq(admin_order_path(order_1))
+    end
+    it 'and I can filter them by status type' do
+
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -20,11 +20,11 @@ describe Order, type: :model do
     it { is_expected.to have_many(:accessories).through(:order_accessories) }
   end
 
-  describe 'methods' do
+  describe 'instance methods' do
     context '#total' do
       it 'should calculate the total order cost' do
         user = create(:user)
-        order = Order.create!(user: user, status: 'ordered')
+        order = Order.create!(user: user, status: 'Ordered')
 
         accessories = create_list(:accessory, 3)
 
@@ -33,6 +33,39 @@ describe Order, type: :model do
         end
 
         expect(order.total).to eq(15.0)
+      end
+    end
+  end
+  describe 'class methods' do
+    before :each do
+      @user = create(:user)
+      @order_1 = Order.create!(user: @user, status: 'Ordered')
+      @order_2 = Order.create!(user: @user, status: 'Ordered')
+      @order_3 = Order.create!(user: @user, status: 'Completed')
+      @order_3 = Order.create!(user: @user, status: 'Paid')
+      @order_3 = Order.create!(user: @user, status: 'Paid')
+      @order_3 = Order.create!(user: @user, status: 'Paid')
+      @order_3 = Order.create!(user: @user, status: 'Cancelled')
+      @order_3 = Order.create!(user: @user, status: 'Cancelled')
+    end
+    context '.ordered_count' do
+      it 'counts the number of orders with status: Ordered' do
+        expect(Order.ordered_count).to eq(2)
+      end
+    end
+    context '.paid_count' do
+      it 'counts the number of orders with status: Paid' do
+        expect(Order.paid_count).to eq(3)
+      end
+    end
+    context '.completed_count' do
+      it 'counts the number of orders with status: Completed' do
+        expect(Order.completed_count).to eq(1)
+      end
+    end
+    context '.cancelled_count' do
+      it 'counts the number of orders with status: Cancelled' do
+        expect(Order.cancelled_count).to eq(2)
       end
     end
   end


### PR DESCRIPTION
# Changes Proposed:
- User story 46
- Admin Dashboard: Admin sees all orders by status and can filter the page by order status
- Admin can update the status of an order 
# Fixes:
- added link to edit info
-

# Checklist:
* Tested on RSPEC✔️
* All test passing?✔️
* Ran on Local Host?✔️

# Mentions:
@Shniks I currently have the Admin order show page nested in the admin controller. The Admin Dashboard links to the Admin Order Show page so I built its bare bones so I could link to it. I know you're working on that story next. Another option would be to have if/else logic on the normal order show page (if current_admin? then show the extra info). Feel free to change my routes if that way is easier - you may have to tweak a few of my tests if that's the case. 